### PR TITLE
people can signup and login with emails without the case mattering

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,8 +10,8 @@ class User < ActiveRecord::Base
   validates :current_city, length: { in: 2..20}, presence: true
 
   def self.confirm(params)
-    @user = User.find_by({email: params[:email]})
+    @user = User.where("email ILIKE ?", params[:email]).first
     @user.try(:authenticate, params[:password])
   end
-  
+
 end


### PR DESCRIPTION
when the database searches for an email with which to match for logging in users, it will do so without the case being a factor.
